### PR TITLE
Add SEO/meta, sitemap/robots, and UI tweaks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Imports:
     shinyjs,
     shinythemes,
     leaflet,
-    rgdal,
     rlang (>= 0.1.2),
     magrittr,
     shinyWidgets,

--- a/R/app_funs.R
+++ b/R/app_funs.R
@@ -1,10 +1,54 @@
+#' SEO metadata shared by CovidTag entry points.
+covidtag_seo_head <- function() {
+    title <- "CovidTag | SARS-CoV-2 variant surveillance in Spain"
+    description <- paste(
+        "CovidTag is an interactive dashboard for SARS-CoV-2 genomic",
+        "surveillance in Spain, tracking variants, mutations and sequencing",
+        "efforts using GISAID data."
+    )
+    url <- "https://covidtag.paseq.org/"
+    image <- "https://covidtag.paseq.org/images/covidTag.png"
+
+    shiny::tags$head(
+        shiny::includeHTML("google-analytics.html"),
+        shiny::tags$meta(name = "description", content = description),
+        shiny::tags$link(rel = "canonical", href = url),
+        shiny::tags$meta(name = "robots", content = "index, follow"),
+        shiny::tags$meta(property = "og:type", content = "website"),
+        shiny::tags$meta(property = "og:title", content = title),
+        shiny::tags$meta(property = "og:description", content = description),
+        shiny::tags$meta(property = "og:url", content = url),
+        shiny::tags$meta(property = "og:image", content = image),
+        shiny::tags$meta(name = "twitter:card", content = "summary"),
+        shiny::tags$meta(name = "twitter:title", content = title),
+        shiny::tags$meta(name = "twitter:description", content = description),
+        shiny::tags$meta(name = "twitter:image", content = image),
+        shiny::tags$script(
+            type = "application/ld+json",
+            shiny::HTML('{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "CovidTag",
+  "url": "https://covidtag.paseq.org/",
+  "description": "CovidTag is an interactive dashboard for SARS-CoV-2 genomic surveillance in Spain, tracking variants, mutations and sequencing efforts using GISAID data.",
+  "applicationCategory": "HealthApplication",
+  "operatingSystem": "Web",
+  "image": "https://covidtag.paseq.org/images/covidTag.png",
+  "publisher": {
+    "@type": "Organization",
+    "name": "PASEQ"
+  }
+}')
+        )
+    )
+}
+
 #' Title
 #'
 #' @export
 ui <- function() {
     shiny::shinyUI(
         shiny::navbarPage(
-            shiny::tags$head(shiny::includeHTML("google-analytics.html")),
             title = shiny::div(
                 shiny::tags$a(
                     href = "http://covidtag.paseq.org",
@@ -60,6 +104,15 @@ ui <- function() {
             theme = shinythemes::shinytheme("flatly"),
             fluid = TRUE,
             collapsible = TRUE,
+            windowTitle = "CovidTag | SARS-CoV-2 variant surveillance in Spain",
+            header = shiny::tagList(
+                covidtag_seo_head(),
+                shiny::tags$head(shiny::tags$style('
+                       nav .container:first-child {
+                           margin-left:100px; width: 100%;
+                       }')),
+                shinyjs::useShinyjs()
+            ),
 
             # TAB1: Overview
             shiny::tabPanel(
@@ -96,12 +149,7 @@ ui <- function() {
                 shiny::br(),
                 shiny::br(),
                 footer
-            ),
-            shiny::tags$head(shiny::tags$style('
-                       nav .container:first-child {
-                           margin-left:100px; width: 100%;
-                       }')),
-            shinyjs::useShinyjs()
+            )
         )
     )
 }
@@ -112,7 +160,7 @@ ui <- function() {
 server <- function() {
     function(input, output, session) {
 
-        shinyjs::runjs('document.title = "CovidTag"')
+        shinyjs::runjs('document.title = "CovidTag | SARS-CoV-2 variant surveillance in Spain"')
         shinylogs::track_usage(storage_mode = shinylogs::store_rds("logs/"))
 
         ## Module tab 1
@@ -175,6 +223,15 @@ ui_2 <- function() {
             theme = shinythemes::shinytheme("flatly"),
             fluid = TRUE,
             collapsible = TRUE,
+            windowTitle = "CovidTag | SARS-CoV-2 variant surveillance in Spain",
+            header = shiny::tagList(
+                covidtag_seo_head(),
+                shiny::tags$head(shiny::tags$style('
+                       nav .container:first-child {
+                           margin-left:100px; width: 100%;
+                       }')),
+                shinyjs::useShinyjs()
+            ),
             
             # TAB2: Overview
             shiny::tabPanel(
@@ -184,13 +241,7 @@ ui_2 <- function() {
                 shiny::br(),
                 shiny::br(),
                 footer
-            ),
-            
-            shiny::tags$head(shiny::tags$style('
-                       nav .container:first-child {
-                           margin-left:100px; width: 100%;
-                       }')),
-            shinyjs::useShinyjs()
+            )
         )
     )
 }
@@ -201,7 +252,7 @@ ui_2 <- function() {
 server_2 <- function() {
     function(input, output, session) {
         
-        shinyjs::runjs('document.title = "CovidTag"')
+        shinyjs::runjs('document.title = "CovidTag | SARS-CoV-2 variant surveillance in Spain"')
         shinylogs::track_usage(storage_mode = shinylogs::store_rds("logs/"))
         
         ## Module tab 1

--- a/R/module_acknowledgements.R
+++ b/R/module_acknowledgements.R
@@ -5,97 +5,95 @@
 acknowledgements_module_ui <- function(id) {
     ns <- shiny::NS(id)
     shiny::pageWithSidebar(
-        headerPanel = shiny::headerPanel(
-            title = shiny::fluidPage(
-                shiny::fixedRow(
-                    shiny::h3(
-                        "Notes for a correct interpretation",
-                        align = "center",
-                        style = "font-weight: bold; font-style: italic;"
-                    )
-                ),
-                shiny::fixedRow(
-                    shiny::h5(
-                        "•	Sampling may not be uniform within the different
+        headerPanel = shiny::fluidPage(
+            shiny::fixedRow(
+                shiny::h3(
+                    "Notes for a correct interpretation",
+                    align = "center",
+                    style = "font-weight: bold; font-style: italic;"
+                )
+            ),
+            shiny::fixedRow(
+                shiny::h5(
+                    "•	Sampling may not be uniform within the different
                         autonomous communities. Therefore, it is important not
                         to assume that the counts/frequencies shown are
                         necessarily representative of the region.",
-                        align = "center",
-                        style = "margin-left: 70px; margin-right: 70px; line-height: 25px;"
-                    ),
-                    shiny::h5(
-                        "• The charts used are based on the sample collection date,
+                    align = "center",
+                    style = "margin-left: 70px; margin-right: 70px; line-height: 25px;"
+                ),
+                shiny::h5(
+                    "• The charts used are based on the sample collection date,
                         and sequencing or GISAID submission date. As a result,
                         this date may differ from when the sample was processed
                         and sequenced, and when the data is released to the public.",
-                        align = "center",
-                        style = "margin-left: 70px; margin-right: 70px; line-height: 25px;"
-                    ),
-                    shiny::h5(
-                        "• In relation with the last consideration, last data
+                    align = "center",
+                    style = "margin-left: 70px; margin-right: 70px; line-height: 25px;"
+                ),
+                shiny::h5(
+                    "• In relation with the last consideration, last data
                         points often has incomplete data and may change as more
                         sequences come in.",
-                        align = "center",
-                        style = "margin-left: 70px; margin-right: 70px; line-height: 25px;"
-                    ),
-                    shiny::h5(
-                        "•	The mutations that define SARS-CoV-2 (CoV-19) lineages
+                    align = "center",
+                    style = "margin-left: 70px; margin-right: 70px; line-height: 25px;"
+                ),
+                shiny::h5(
+                    "•	The mutations that define SARS-CoV-2 (CoV-19) lineages
                         are updated every few days. Therefore, displayed data is
                         susceptible to change over time.",
-                        align = "center",
-                        style = "margin-left: 70px; margin-right: 70px; line-height: 25px;"
-                    )
-                ),
-                shiny::br(),
-                shiny::fixedRow(
-                    shiny::h3("Acknowledgements",
-                              align = "center",
-                              style = "font-weight: bold; font-style: italic;"),
-                ),
-                shiny::fixedRow(
-                    shiny::h5(
-                        "We are grateful to the data contributors who shared the
+                    align = "center",
+                    style = "margin-left: 70px; margin-right: 70px; line-height: 25px;"
+                )
+            ),
+            shiny::br(),
+            shiny::fixedRow(
+                shiny::h3("Acknowledgements",
+                          align = "center",
+                          style = "font-weight: bold; font-style: italic;"),
+            ),
+            shiny::fixedRow(
+                shiny::h5(
+                    "We are grateful to the data contributors who shared the
                         data used in this Web Application via the GISAID
                         Initia-tive*: the Authors, the Originating Laboratories
                         responsible for obtaining the specimens, and the Submitting
                         Laboratories that generated the genetic sequences and metadata.",
-                        align = "center",
-                        style = "margin-left: 150px; margin-right: 150px; line-height: 25px;"
-                    )
-                ),
-                shiny::fixedRow(
-                    shiny::h5(
-                        "* (a) Elbe, S., and Buckland-Merrett, G. (2017) Data,
+                    align = "center",
+                    style = "margin-left: 150px; margin-right: 150px; line-height: 25px;"
+                )
+            ),
+            shiny::fixedRow(
+                shiny::h5(
+                    "* (a) Elbe, S., and Buckland-Merrett, G. (2017) Data,
                         disease and diplomacy: GISAID’s innovative contribution
                         to global health. Global Challenges, 1:33-46.
                         DOI: ",
-                        shiny::a(
-                            " 10.1002/gch2.1018",
-                            href = "https://onlinelibrary.wiley.com/doi/full/10.1002/gch2.1018",
-                            target = "_blank"
-                        ),
-                        " PMCID: ",
-                        shiny::a(
-                            " 31565258",
-                            href = "https://pubmed.ncbi.nlm.nih.gov/31565258/",
-                            target = "_blank"
-                        ),
-                        " (b) Shu, Y., McCauley, J. (2017) GISAID: From vision
+                    shiny::a(
+                        " 10.1002/gch2.1018",
+                        href = "https://onlinelibrary.wiley.com/doi/full/10.1002/gch2.1018",
+                        target = "_blank"
+                    ),
+                    " PMCID: ",
+                    shiny::a(
+                        " 31565258",
+                        href = "https://pubmed.ncbi.nlm.nih.gov/31565258/",
+                        target = "_blank"
+                    ),
+                    " (b) Shu, Y., McCauley, J. (2017) GISAID: From vision
                         to reality. EuroSurveillance, 22(13) DOI: ",
-                        shiny::a(
-                            " 10.2807/1560-7917.ES.2017.22.13.30494",
-                            href = "https://www.eurosurveillance.org/content/10.2807/1560-7917.ES.2017.22.13.30494",
-                            target = "_blank"
-                        ),
-                        " PMCID: ",
-                        shiny::a(
-                            " PMC5388101",
-                            href = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5388101/",
-                            target = "_blank"
-                        ),
-                        align = "center",
-                        style = "margin-left: 150px; margin-right: 150px; line-height: 25px;"
-                    )
+                    shiny::a(
+                        " 10.2807/1560-7917.ES.2017.22.13.30494",
+                        href = "https://www.eurosurveillance.org/content/10.2807/1560-7917.ES.2017.22.13.30494",
+                        target = "_blank"
+                    ),
+                    " PMCID: ",
+                    shiny::a(
+                        " PMC5388101",
+                        href = "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5388101/",
+                        target = "_blank"
+                    ),
+                    align = "center",
+                    style = "margin-left: 150px; margin-right: 150px; line-height: 25px;"
                 )
             )
         ),
@@ -114,4 +112,3 @@ acknowledgements_module_server <- function(id) {
         # empty
     })
 }
-

--- a/R/module_data_dw.R
+++ b/R/module_data_dw.R
@@ -6,7 +6,7 @@
 data_dw_module_ui <- function(id) {
   ns <- shiny::NS(id)
   shiny::pageWithSidebar(
-    headerPanel = shiny::headerPanel(""),
+    headerPanel = shiny::div(class = "col-sm-12", shiny::h1("")),
 
     sidebarPanel = NULL,
     # main
@@ -54,6 +54,4 @@ data_dw_module_server <- function(id) {
 
   })
 }
-
-
 

--- a/R/module_per_ca.R
+++ b/R/module_per_ca.R
@@ -5,7 +5,7 @@
 per_ca_module_ui <- function(id) {
     ns <- shiny::NS(id)
     shiny::pageWithSidebar(
-        headerPanel = shiny::headerPanel(""),
+        headerPanel = shiny::div(class = "col-sm-12", shiny::h1("")),
         sidebarPanel = shiny::sidebarPanel(
             width = 3,
             shiny::h5(
@@ -114,4 +114,3 @@ per_ca_module_server <- function(id) {
         })
     })
 }
-

--- a/R/module_per_variant.R
+++ b/R/module_per_variant.R
@@ -8,7 +8,7 @@
 per_variant_module_ui <- function(id) {
     ns <- shiny::NS(id)
     shiny::pageWithSidebar(
-        headerPanel = shiny::headerPanel(""),
+        headerPanel = shiny::div(class = "col-sm-12", shiny::h1("")),
 
         # sidebar
         sidebarPanel = shiny::sidebarPanel(
@@ -95,4 +95,3 @@ per_variant_module_server <- function(id) {
             shiny::bindCache(input$variant)
     })
 }
-

--- a/www/robots.txt
+++ b/www/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://covidtag.paseq.org/sitemap.xml

--- a/www/sitemap.xml
+++ b/www/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://covidtag.paseq.org/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
Introduce covidtag_seo_head to inject SEO/meta tags (OG, Twitter, schema.org) and include google-analytics; set windowTitle and update document.title. Add sitemap.xml and robots.txt. Remove rgdal from DESCRIPTION. Replace empty headerPanel usages with a consistent div header (col-sm-12 h1) across modules and tidy acknowledgements UI layout and formatting.