### PR TITLE
Add amd64 platform and build deps to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
-FROM microbialgenomics/shiny-geospatial:4.1.2
+FROM --platform=linux/amd64 microbialgenomics/shiny-geospatial:4.1.2
 
 # Copy covidseq_dev and set permission
 RUN rm -rf /srv/shiny-server/*
 ADD ./covidapp /srv/shiny-server
 RUN chmod -R +r /srv/shiny-server
 RUN rm /srv/shiny-server/app_customData.R
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libuv1 \
+    libuv1-dev \
+    cmake \
+    make \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install deps and package
 RUN R -e "devtools::install_deps('/srv/shiny-server')"


### PR DESCRIPTION
Specify --platform=linux/amd64 for the base image and install required build dependencies (libuv1, libuv1-dev, cmake, make, pkg-config) so R package installation via devtools can compile native components. Cleans apt lists after install to reduce image size.